### PR TITLE
Reduce runtime deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule VBT.Credo.MixProject do
   defp deps do
     [
       {:credo, "~> 1.1", runtime: false},
-      {:dialyxir, "~> 0.5", runtime: false, only: [:dev, :test]},
+      {:dialyxir, "~> 0.5", runtime: false},
       {:stream_data, "~> 0.4", only: [:test, :dev]},
       {:ecto, "~> 3.0", optional: true},
       {:absinthe, "~> 1.4", optional: true}

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule VBT.Credo.MixProject do
 
   defp deps do
     [
-      {:credo, "~> 1.1"},
+      {:credo, "~> 1.1", runtime: false},
       {:dialyxir, "~> 0.5", runtime: false, only: [:dev, :test]},
       {:stream_data, "~> 0.4", only: [:test, :dev]},
       {:ecto, "~> 3.0", optional: true},
@@ -42,7 +42,7 @@ defmodule VBT.Credo.MixProject do
 
   defp dialyzer() do
     [
-      plt_add_apps: [:mix, :eex, :ecto, :absinthe]
+      plt_add_apps: [:mix, :eex, :ecto, :absinthe, :credo]
     ]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 # credo:disable-for-this-file
+Application.ensure_all_started(:credo)
 
 Code.require_file("support/test_application.exs", __DIR__)
 


### PR DESCRIPTION
## Changes

- `credo` is now a compile-time dependency. As a result, the library won't be included in OTP release of client projects.
- `dialyxir` can be used in prod too. Since it's a compile-time dependency, it still won't be included in OTP release.

## Checklist:

- [x] I have performed a self-review of my own code
