### PR TITLE
Fix crash in changeset_error

### DIFF
--- a/lib/vbt/absinthe/resolver_helper.ex
+++ b/lib/vbt/absinthe/resolver_helper.ex
@@ -54,7 +54,9 @@ defmodule VBT.Absinthe.ResolverHelper do
   defp error_message("is invalid" = template, _values, _opts), do: template
 
   defp error_message(template, values, opts) do
-    Enum.reduce(values, template, fn {key, value}, acc ->
+    values
+    |> Stream.filter(fn {key, _value} -> String.contains?(template, "%{#{key}}") end)
+    |> Enum.reduce(template, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", value_formatter(opts).(key, value))
     end)
   end

--- a/test/vbt/absinthe/resolver_helper_test.exs
+++ b/test/vbt/absinthe/resolver_helper_test.exs
@@ -101,5 +101,15 @@ defmodule VBT.Absinthe.ResolverHelperTest do
 
       assert errors == [%{extensions: %{field: "name"}, message: "formatted key1 error1"}]
     end
+
+    test "correctly handles unsafe_validate_unique error" do
+      errors =
+        %User{}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(:name, "error", validation: :unsafe_unique, fields: [:name])
+        |> ResolverHelper.changeset_errors()
+
+      assert errors == [%{extensions: %{field: "name"}, message: "error"}]
+    end
   end
 end


### PR DESCRIPTION
## Changes

Localdrive team reported a crash, which was caused by

```elixir
errors: [
    email: {"has already been taken",
     [validation: :unsafe_unique, fields: [:email]]}
  ]
```

in the changeset.

It appears that `unsafe_validate_unique` adds some rich metadata (in this case `fields`) which will casue `to_string` to raise an error.

As an easy fix, I'm ignoring any fields which are not referenced in the string.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
