### PR TITLE
Graphql client

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -15,8 +15,7 @@
         {VBT.Credo.Check.Consistency.FileLocation,
          exclude: [Path.join(~w/test integration skafolder_tester/)]},
         {Credo.Check.Readability.Specs, []},
-        {Credo.Check.Design.TagTODO, false},
-        {Credo.Check.Readability.ModuleDoc, false}
+        {Credo.Check.Design.TagTODO, false}
       ]
     }
   ]

--- a/.credo.exs
+++ b/.credo.exs
@@ -14,6 +14,7 @@
         {VBT.Credo.Check.Readability.WithPlaceholder, []},
         {VBT.Credo.Check.Consistency.FileLocation,
          exclude: [Path.join(~w/test integration skafolder_tester/)]},
+        {Credo.Check.Readability.Specs, []},
         {Credo.Check.Design.TagTODO, false},
         {Credo.Check.Readability.ModuleDoc, false}
       ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,6 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  import_deps: [:stream_data, :ecto, :absinthe],
+  import_deps: [:stream_data, :ecto, :absinthe, :plug, :phoenix],
   locals_without_parens: [gen: 1, gen: 2]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,8 @@
 use Mix.Config
 
-config :stream_data,
-  max_runs: if(System.get_env("CI"), do: 100, else: 10)
-
-config :vbt, VBT.Mailer, adapter: Bamboo.TestAdapter
+if Mix.env() == :test do
+  config :phoenix, :json_library, Jason
+  config :stream_data, max_runs: if(System.get_env("CI"), do: 100, else: 10)
+  config :vbt, VBT.Mailer, adapter: Bamboo.TestAdapter
+  config :vbt, VBT.GraphqlServer, server: false
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 if Mix.env() == :test do
+  config :logger, level: :warn
   config :phoenix, :json_library, Jason
   config :stream_data, max_runs: if(System.get_env("CI"), do: 100, else: 10)
   config :vbt, VBT.Mailer, adapter: Bamboo.TestAdapter

--- a/lib/mix/tasks/vbt/bootstrap.ex
+++ b/lib/mix/tasks/vbt/bootstrap.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Vbt.Bootstrap do
+  @shortdoc "Boostrap project (generate everything!!!)"
   @moduledoc "Boostrap project (generate everything!!!)"
 
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
-  @shortdoc "Boostrap project (generate everything!!!)"
   def run(args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.bootstrap can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/bootstrap.ex
+++ b/lib/mix/tasks/vbt/bootstrap.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Bootstrap do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @shortdoc "Boostrap project (generate everything!!!)"

--- a/lib/mix/tasks/vbt/bootstrap.ex
+++ b/lib/mix/tasks/vbt/bootstrap.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Tasks.Vbt.Bootstrap do
+  @moduledoc "Boostrap project (generate everything!!!)"
+
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/circleci.ex
+++ b/lib/mix/tasks/vbt/gen/circleci.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Tasks.Vbt.Gen.Circleci do
+  @moduledoc "Generate CircleCI config files"
+
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/circleci.ex
+++ b/lib/mix/tasks/vbt/gen/circleci.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Circleci do
+  @shortdoc "Generate CircleCI config files"
   @moduledoc "Generate CircleCI config files"
 
   # credo:disable-for-this-file Credo.Check.Readability.Specs
@@ -6,7 +7,6 @@ defmodule Mix.Tasks.Vbt.Gen.Circleci do
 
   @template Path.join(["skf.gen.circleci", "config.yml"])
 
-  @shortdoc "Generate CircleCI config files"
   def run(_args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.circleci can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/circleci.ex
+++ b/lib/mix/tasks/vbt/gen/circleci.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Circleci do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template Path.join(["skf.gen.circleci", "config.yml"])

--- a/lib/mix/tasks/vbt/gen/credo.ex
+++ b/lib/mix/tasks/vbt/gen/credo.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Credo do
+  @moduledoc "Generate credo config files"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/credo.ex
+++ b/lib/mix/tasks/vbt/gen/credo.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Credo do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template Path.join(["skf.gen.credo", ".credo.exs"])

--- a/lib/mix/tasks/vbt/gen/credo.ex
+++ b/lib/mix/tasks/vbt/gen/credo.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Vbt.Gen.Credo do
+  @shortdoc "Generate credo config files"
   @moduledoc "Generate credo config files"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template Path.join(["skf.gen.credo", ".credo.exs"])
 
-  @shortdoc "Generate credo config files"
   def run(_args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.credo can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/dialyzer.ex
+++ b/lib/mix/tasks/vbt/gen/dialyzer.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Dialyzer do
+  @moduledoc "Generate dialyzer files"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/dialyzer.ex
+++ b/lib/mix/tasks/vbt/gen/dialyzer.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Dialyzer do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @shortdoc "Generate dialyzer files"

--- a/lib/mix/tasks/vbt/gen/dialyzer.ex
+++ b/lib/mix/tasks/vbt/gen/dialyzer.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Vbt.Gen.Dialyzer do
+  @shortdoc "Generate dialyzer files"
   @moduledoc "Generate dialyzer files"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
-  @shortdoc "Generate dialyzer files"
   def run(_args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.dialyzer can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/docker.ex
+++ b/lib/mix/tasks/vbt/gen/docker.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Docker do
+  @shortdoc "Generate docker files"
   @moduledoc "Generate docker files"
 
   # credo:disable-for-this-file Credo.Check.Readability.Specs
@@ -11,8 +12,6 @@ defmodule Mix.Tasks.Vbt.Gen.Docker do
     Path.join(["skf.gen.docker", "entrypoint.sh"]),
     Path.join(["skf.gen.docker", "docker-compose.yml"])
   ]
-
-  @shortdoc "Generate docker files"
 
   def run(_args) do
     if Mix.Project.umbrella?() do

--- a/lib/mix/tasks/vbt/gen/docker.ex
+++ b/lib/mix/tasks/vbt/gen/docker.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Docker do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @templates [

--- a/lib/mix/tasks/vbt/gen/docker.ex
+++ b/lib/mix/tasks/vbt/gen/docker.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Tasks.Vbt.Gen.Docker do
+  @moduledoc "Generate docker files"
+
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/github_pr_template.ex
+++ b/lib/mix/tasks/vbt/gen/github_pr_template.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.GithubPrTemplate do
+  @moduledoc "Generate Github pull request template"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/github_pr_template.ex
+++ b/lib/mix/tasks/vbt/gen/github_pr_template.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.GithubPrTemplate do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template Path.join(["skf.gen.github_pr_template", "pull_request_template.md"])

--- a/lib/mix/tasks/vbt/gen/github_pr_template.ex
+++ b/lib/mix/tasks/vbt/gen/github_pr_template.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Vbt.Gen.GithubPrTemplate do
+  @shortdoc "Generate Github pull request template"
   @moduledoc "Generate Github pull request template"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template Path.join(["skf.gen.github_pr_template", "pull_request_template.md"])
 
-  @shortdoc "Generate Github pull request template"
   def run(_args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.github_pr_template can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/heroku.ex
+++ b/lib/mix/tasks/vbt/gen/heroku.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Heroku do
+  @moduledoc "Generate Heroku config"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 

--- a/lib/mix/tasks/vbt/gen/heroku.ex
+++ b/lib/mix/tasks/vbt/gen/heroku.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Vbt.Gen.Heroku do
+  @shortdoc "Generate Heroku config"
   @moduledoc "Generate Heroku config"
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template_root "skf.gen.heroku"
 
-  @shortdoc "Generate Heroku config"
   def run(_args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.heroku can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/heroku.ex
+++ b/lib/mix/tasks/vbt/gen/heroku.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Heroku do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   use Mix.Task
 
   @template_root "skf.gen.heroku"

--- a/lib/mix/tasks/vbt/gen/makefile.ex
+++ b/lib/mix/tasks/vbt/gen/makefile.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Vbt.Gen.Makefile do
+  @shortdoc "Generate Makefile"
   @moduledoc """
   Generates a Makefile.
 
@@ -14,7 +15,6 @@ defmodule Mix.Tasks.Vbt.Gen.Makefile do
   @switches [cloud: :string, docker: :boolean]
   @defaults [cloud: "heroku", docker: true]
 
-  @shortdoc "Generate Makefile"
   def run(args) do
     if Mix.Project.umbrella?() do
       Mix.raise("mix vbt.gen.makefile can only be run inside an application directory")

--- a/lib/mix/tasks/vbt/gen/makefile.ex
+++ b/lib/mix/tasks/vbt/gen/makefile.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Vbt.Gen.Makefile do
 
     - `--cloud` - specifies the target cloud. Possible values are `heroku` (default), and `aws`.
   """
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
 
   use Mix.Task
 

--- a/lib/mix/vbt.ex
+++ b/lib/mix/vbt.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Vbt do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
   def bindings(opts \\ [], defaults \\ []) do
     app = otp_app()
     additional_bindings = Keyword.merge(defaults, opts)

--- a/lib/mix/vbt.ex
+++ b/lib/mix/vbt.ex
@@ -1,4 +1,6 @@
 defmodule Mix.Vbt do
+  @moduledoc false
+
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   def bindings(opts \\ [], defaults \\ []) do
     app = otp_app()

--- a/lib/vbt/credo/check/consistency/file_location.ex
+++ b/lib/vbt/credo/check/consistency/file_location.ex
@@ -1,5 +1,6 @@
 defmodule VBT.Credo.Check.Consistency.FileLocation do
   @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
 
   @checkdoc """
   File location should follow the namespace hierarchy of the module it defines.

--- a/lib/vbt/credo/check/consistency/module_layout.ex
+++ b/lib/vbt/credo/check/consistency/module_layout.ex
@@ -5,25 +5,26 @@ defmodule VBT.Credo.Check.Consistency.ModuleLayout do
   @checkdoc """
   Module parts should appear in the following order:
 
-     1. @moduledoc
-     2. @behaviour
-     3. use
-     4. import
-     5. alias
-     6. require
-     7. custom module attributes
-     8. defstruct
-     9. @opaque
-    10. @type
-    11. @typep
-    12. @callback
-    13. @macrocallback
-    14. @optional_callbacks
-    15. public guards
-    16. public macros
-    17. public functions
-    18. behaviour callbacks
-    19. private functions
+     1. @shortdoc
+     2. @moduledoc
+     3. @behaviour
+     4. use
+     5. import
+     6. alias
+     7. require
+     8. custom module attributes
+     9. defstruct
+    10. @opaque
+    11. @type
+    12. @typep
+    13. @callback
+    14. @macrocallback
+    15. @optional_callbacks
+    16. public guards
+    17. public macros
+    18. public functions
+    19. behaviour callbacks
+    20. private functions
 
   This order has been adapted from https://github.com/christopheradams/elixir_style_guide#module-attribute-ordering.
   """
@@ -38,6 +39,7 @@ defmodule VBT.Credo.Check.Consistency.ModuleLayout do
   alias VBT.Credo.ModulePartExtractor
 
   @expected_order Map.new(Enum.with_index(~w/
+    shortdoc
     moduledoc
     behaviour
     use

--- a/lib/vbt/credo/check/consistency/module_layout.ex
+++ b/lib/vbt/credo/check/consistency/module_layout.ex
@@ -1,5 +1,6 @@
 defmodule VBT.Credo.Check.Consistency.ModuleLayout do
   @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
 
   @checkdoc """
   Module parts should appear in the following order:

--- a/lib/vbt/credo/check/readability/with_placeholder.ex
+++ b/lib/vbt/credo/check/readability/with_placeholder.ex
@@ -1,5 +1,6 @@
 defmodule VBT.Credo.Check.Readability.WithPlaceholder do
   @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
 
   @checkdoc """
   Avoid using with placeholders for error reporting.

--- a/lib/vbt/credo/module_part_extractor.ex
+++ b/lib/vbt/credo/module_part_extractor.ex
@@ -3,6 +3,7 @@ defmodule VBT.Credo.ModulePartExtractor do
 
   @type module_part ::
           :moduledoc
+          | :shortdoc
           | :behaviour
           | :use
           | :import
@@ -164,7 +165,7 @@ defmodule VBT.Credo.ModulePartExtractor do
     do: set_next_fun_modifier(state, if(value == false, do: nil, else: :impl))
 
   defp analyze(state, {:@, meta, [{attribute, _, _}]})
-       when attribute in ~w/moduledoc behaviour type typep opaque callback macrocallback optional_callbacks/a,
+       when attribute in ~w/moduledoc shortdoc behaviour type typep opaque callback macrocallback optional_callbacks/a,
        do: add_module_element(state, attribute, meta)
 
   defp analyze(state, {:@, _meta, [{ignore_attribute, _, _}]})

--- a/lib/vbt/graphql/case.ex
+++ b/lib/vbt/graphql/case.ex
@@ -141,7 +141,15 @@ defmodule VBT.Graphql.Case do
       import VBT.Graphql.Case, except: [set_config: 1]
 
       setup do
-        unquote(module).set_config(unquote(opts))
+        opts = unquote(opts)
+        unquote(module).set_config(opts)
+
+        with {:ok, repo} <- Keyword.fetch(opts, :repo) do
+          Sandbox.checkout(repo)
+          unless opts[:async], do: Sandbox.mode(repo, {:shared, self()})
+        end
+
+        :ok
       end
     end
   end

--- a/lib/vbt/graphql/case.ex
+++ b/lib/vbt/graphql/case.ex
@@ -98,6 +98,7 @@ defmodule VBT.Graphql.Case do
   end
 
   @doc false
+  # credo:disable-for-next-line Credo.Check.Readability.Specs
   def set_config(opts) do
     Process.put(__MODULE__, opts)
     :ok

--- a/lib/vbt/graphql/case.ex
+++ b/lib/vbt/graphql/case.ex
@@ -1,0 +1,148 @@
+defmodule VBT.Graphql.Case do
+  @moduledoc """
+  ExUnit case template for writing tests which issue GraphQL requests.
+
+  Example:
+
+      defmodule SomeTest do
+        use VBT.Graphql.Case,
+          endpoint: MyEndpoint,
+          api_path: "/api/graphql",
+          repo: MyRepo,
+          async: true
+
+        describe "current_user" do
+          test "returns current user's login" do
+            {:ok, token} = call(auth_query, variables: %{login: login, password: password})
+            assert {:ok, data} = call(current_user_query, auth: token)
+            assert data.login == "expected login"
+          end
+
+          test "returns an error when not authenticated" do
+            assert {:ok, response} = call(current_user_query, auth: token)
+            assert "unauthenticated" in errors(response)
+          end
+      end
+  """
+  use ExUnit.CaseTemplate
+  alias Ecto.Adapters.SQL.Sandbox
+
+  @type call_opts :: [
+          variables: variables,
+          auth: String.t() | nil,
+          headers: [header],
+          endpoint: module,
+          api_path: String.t()
+        ]
+
+  @type variables :: %{atom => any} | Keyword.t()
+  @type header :: {String.t(), String.t()}
+
+  @type response :: %{data: data, errors: [error]}
+
+  @type data :: %{atom => data_value}
+  @type data_value :: number | String.t() | data | [data_value]
+
+  @type error :: %{
+          required(:message) => String.t(),
+          optional(:path) => [String.t()],
+          optional(:locations) => [%{column: non_neg_integer, line: non_neg_integer}],
+          optional(:extensions) => [%{field: String.t()}]
+        }
+
+  # ------------------------------------------------------------------------
+  # API
+  # ------------------------------------------------------------------------
+
+  @doc "Makes a GraphQL query call."
+  @spec call(String.t(), call_opts) :: {:ok, data} | {:error, response}
+  def call(query_string, opts \\ []) do
+    opts = normalize_opts(opts)
+    query_body = %{query: query_string, variables: variables(opts)}
+
+    response =
+      Phoenix.ConnTest.build_conn()
+      |> add_headers(opts)
+      |> Phoenix.ConnTest.dispatch(endpoint(opts), :post, api_path(opts), query_body)
+      |> Phoenix.ConnTest.json_response(200)
+      |> normalize_keys()
+
+    if Map.has_key?(response, :errors),
+      do: {:error, response},
+      else: {:ok, response.data}
+  end
+
+  @doc "Makes a GraphQL call, returning data on success, raising an assertion error otherwise."
+  @spec call!(String.t(), call_opts) :: data
+  def call!(query_string, opts \\ []) do
+    case call(query_string, opts) do
+      {:error, response} ->
+        errors = inspect(response.errors, limit: :infinity, pretty: true)
+        raise ExUnit.AssertionError, "GraphQL call failed\n\n#{errors}"
+
+      {:ok, data} ->
+        data
+    end
+  end
+
+  @doc "Returns error messages from the GraphQL response errors."
+  @spec errors(response) :: [String.t()]
+  def errors(call_result), do: Enum.map(call_result.errors, & &1.message)
+
+  @doc "Returns error messages for the given field from the GraphQL response errors."
+  @spec field_errors(response, String.t()) :: [String.t()]
+  def field_errors(response, field) do
+    response.errors
+    |> Stream.filter(&match?(%{extensions: %{field: ^field}}, &1))
+    |> Enum.map(& &1.message)
+  end
+
+  @doc false
+  def set_config(opts) do
+    Process.put(__MODULE__, opts)
+    :ok
+  end
+
+  # ------------------------------------------------------------------------
+  # Private
+  # ------------------------------------------------------------------------
+
+  defp config, do: Process.get(__MODULE__, [])
+
+  defp endpoint(opts), do: Keyword.fetch!(opts, :endpoint)
+  defp api_path(opts), do: Keyword.fetch!(opts, :api_path)
+  defp variables(opts), do: Keyword.get(opts, :variables)
+  defp headers(opts), do: Keyword.fetch!(opts, :headers)
+
+  defp normalize_opts(opts) do
+    opts = config() |> Keyword.merge(headers: []) |> Keyword.merge(opts)
+
+    case Keyword.pop(opts, :auth) do
+      {nil, _} -> opts
+      {token, opts} -> Keyword.update!(opts, :headers, &[auth_header(token) | &1])
+    end
+  end
+
+  defp auth_header(token), do: {"authorization", "Bearer #{token}"}
+
+  defp add_headers(conn, opts), do: Enum.reduce(headers(opts), conn, &add_header(&2, &1))
+  defp add_header(conn, {key, value}), do: Plug.Conn.put_req_header(conn, key, value)
+
+  defp normalize_keys(%{} = map),
+    do: Enum.into(map, %{}, fn {key, value} -> {normalize_key(key), normalize_keys(value)} end)
+
+  defp normalize_keys(list) when is_list(list), do: Enum.map(list, &normalize_keys/1)
+  defp normalize_keys(other), do: other
+
+  defp normalize_key(key), do: key |> Macro.underscore() |> String.to_atom()
+
+  using opts do
+    quote bind_quoted: [opts: opts, module: unquote(__MODULE__)] do
+      import VBT.Graphql.Case, except: [set_config: 1]
+
+      setup do
+        unquote(module).set_config(unquote(opts))
+      end
+    end
+  end
+end

--- a/lib/vbt/skafolder.ex
+++ b/lib/vbt/skafolder.ex
@@ -1,5 +1,6 @@
 defmodule VBT.Skafolder do
   @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
 
   def generate_file(content, file) do
     Mix.Generator.create_file(file, content)

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule VBT.Credo.MixProject do
 
   defp dialyzer() do
     [
-      plt_add_apps: [:mix, :eex, :ecto, :absinthe, :credo, :bamboo]
+      plt_add_apps: ~w/mix eex ecto absinthe credo bamboo phoenix ex_unit phoenix_pubsub/a
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,8 @@ defmodule VBT.Credo.MixProject do
       {:stream_data, "~> 0.4", only: [:test, :dev]},
       {:ecto, "~> 3.0", optional: true},
       {:absinthe, "~> 1.4", optional: true},
+      {:absinthe_plug, "~> 1.4"},
+      {:phoenix, "~> 1.4", optional: true},
       {:bamboo, "~> 1.0", optional: true}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "absinthe": {:hex, :absinthe, "1.4.16", "0933e4d9f12652b12115d5709c0293a1bf78a22578032e9ad0dad4efee6b9eb1", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "absinthe_plug": {:hex, :absinthe_plug, "1.4.7", "939b6b9e1c7abc6b399a5b49faa690a1fbb55b195c670aa35783b14b08ccec7a", [:mix], [{:absinthe, "~> 1.4.11", [hex: :absinthe, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.2 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "bamboo": {:hex, :bamboo, "1.3.0", "9ab7c054f1c3435464efcba939396c29c5e1b28f73c34e1f169e0881297a3141", [:mix], [{:hackney, ">= 1.13.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
@@ -14,9 +15,12 @@
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.4.11", "d112c862f6959f98e6e915c3b76c7a87ca3efd075850c8daa7c3c7a609014b0d", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.1", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.8.1 or ~> 1.9", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/integration/skafolder_tester/mix.lock
+++ b/test/integration/skafolder_tester/mix.lock
@@ -1,6 +1,11 @@
 %{
+  "absinthe": {:hex, :absinthe, "1.4.16", "0933e4d9f12652b12115d5709c0293a1bf78a22578032e9ad0dad4efee6b9eb1", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "absinthe_plug": {:hex, :absinthe_plug, "1.4.7", "939b6b9e1c7abc6b399a5b49faa690a1fbb55b195c670aa35783b14b08ccec7a", [:mix], [{:absinthe, "~> 1.4.11", [hex: :absinthe, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.2 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "1.1.5", "caec7a3cadd2e58609d7ee25b3931b129e739e070539ad1a0cd7efeeb47014f4", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
 }

--- a/test/support/vbt/graphql_server.ex
+++ b/test/support/vbt/graphql_server.ex
@@ -1,6 +1,7 @@
 defmodule VBT.GraphqlServer do
   use Phoenix.Endpoint, otp_app: :vbt
   import Phoenix.Controller, only: [accepts: 2]
+  import VBT.Absinthe.ResolverHelper
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
@@ -8,15 +9,65 @@ defmodule VBT.GraphqlServer do
     json_decoder: Jason
 
   plug :accepts, ["json"]
+  plug :read_auth_token
   plug Absinthe.Plug, schema: __MODULE__.Schema
+
+  defp read_auth_token(conn, _params) do
+    auth_token =
+      Plug.Conn.get_req_header(conn, "authorization")
+      |> Enum.find(&String.starts_with?(&1, "Bearer "))
+      |> case do
+        "Bearer " <> token -> token
+        nil -> nil
+      end
+
+    Absinthe.Plug.put_options(conn, context: %{auth_token: auth_token})
+  end
 
   defmodule Schema do
     use Absinthe.Schema
 
     query do
-      field :health, :string do
-        resolve fn _, _ -> {:ok, "ok"} end
+      field :order, :order do
+        arg :id, non_null(:integer)
+
+        resolve fn arg, _ ->
+          order = %{id: arg.id, order_items: [order_item(1), order_item(2)]}
+          {:ok, order}
+        end
+      end
+
+      field :login, :string do
+        resolve fn _, resolution -> {:ok, resolution.context.auth_token} end
       end
     end
+
+    mutation do
+      field :register_user, :string do
+        resolve fn _, _ ->
+          types = %{login: :string, password: :string}
+
+          changeset_errors =
+            {%{}, types}
+            |> Ecto.Changeset.cast(%{}, Map.keys(types))
+            |> Ecto.Changeset.validate_required([:login])
+            |> changeset_errors()
+
+          {:error, ["invalid login data" | changeset_errors]}
+        end
+      end
+    end
+
+    object :order do
+      field :id, non_null(:integer)
+      field :order_items, non_null(list_of(:order_item))
+    end
+
+    object :order_item do
+      field :product_name, non_null(:string)
+      field :quantity, non_null(:integer)
+    end
+
+    defp order_item(id), do: %{product_name: "product #{id}", quantity: id}
   end
 end

--- a/test/support/vbt/graphql_server.ex
+++ b/test/support/vbt/graphql_server.ex
@@ -1,4 +1,5 @@
 defmodule VBT.GraphqlServer do
+  @moduledoc false
   use Phoenix.Endpoint, otp_app: :vbt
   import Phoenix.Controller, only: [accepts: 2]
   import VBT.Absinthe.ResolverHelper
@@ -25,6 +26,7 @@ defmodule VBT.GraphqlServer do
   end
 
   defmodule Schema do
+    @moduledoc false
     use Absinthe.Schema
 
     query do

--- a/test/support/vbt/graphql_server.ex
+++ b/test/support/vbt/graphql_server.ex
@@ -1,0 +1,22 @@
+defmodule VBT.GraphqlServer do
+  use Phoenix.Endpoint, otp_app: :vbt
+  import Phoenix.Controller, only: [accepts: 2]
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json, Absinthe.Plug.Parser],
+    pass: ["*/*"],
+    json_decoder: Jason
+
+  plug :accepts, ["json"]
+  plug Absinthe.Plug, schema: __MODULE__.Schema
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    query do
+      field :health, :string do
+        resolve fn _, _ -> {:ok, "ok"} end
+      end
+    end
+  end
+end

--- a/test/support/vbt/mailer.ex
+++ b/test/support/vbt/mailer.ex
@@ -1,3 +1,4 @@
 defmodule VBT.Mailer do
+  @moduledoc false
   use Bamboo.Mailer, otp_app: :vbt
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 # credo:disable-for-this-file
+VBT.GraphqlServer.start_link()
+
 Application.ensure_all_started(:credo)
 
 Code.require_file("support/test_application.exs", __DIR__)

--- a/test/vbt/credo/check/consistency/module_layout_test.exs
+++ b/test/vbt/credo/check/consistency/module_layout_test.exs
@@ -6,6 +6,7 @@ defmodule VBT.Credo.Check.Consistency.ModuleLayoutTest do
   test "no errors are reported on a successful layout" do
     """
     defmodule Test do
+      @shortdoc "shortdoc"
       @moduledoc "some doc"
 
       @behaviour GenServer
@@ -81,6 +82,20 @@ defmodule VBT.Credo.Check.Consistency.ModuleLayoutTest do
     """
     |> to_source_file
     |> refute_issues(@described_check)
+  end
+
+  test "shortdoc must appear before moduledoc" do
+    [issue] =
+      """
+      defmodule Test do
+        @moduledoc "some doc"
+        @shortdoc "shortdoc"
+      end
+      """
+      |> to_source_file
+      |> assert_issue(@described_check)
+
+    assert issue.message == "shortdoc must appear before moduledoc"
   end
 
   test "moduledoc must appear before behaviour" do

--- a/test/vbt/graphql/case_test.exs
+++ b/test/vbt/graphql/case_test.exs
@@ -1,0 +1,78 @@
+defmodule VBT.Graphql.CaseTest do
+  use VBT.Graphql.Case, async: true, endpoint: VBT.GraphqlServer, api_path: "/"
+
+  describe "call" do
+    test "returns data on success" do
+      assert {:ok, data} = call(order_query(), variables: %{order_id: 1})
+
+      assert data.order == %{
+               id: 1,
+               order_items: [
+                 %{product_name: "product 1", quantity: 1},
+                 %{product_name: "product 2", quantity: 2}
+               ]
+             }
+    end
+
+    test "returns entire response on failure" do
+      assert {:error, %{data: data, errors: errors}} = call(failing_query())
+      assert data == %{register_user: nil}
+      assert [%{message: error1}, %{message: error2}] = errors
+      assert error1 == "invalid login data"
+      assert error2 == "can't be blank"
+    end
+
+    test "propagates authentication header" do
+      auth_token = Base.encode64(:crypto.strong_rand_bytes(16), padding: false)
+      assert call("query {login}", auth: auth_token) == {:ok, %{login: auth_token}}
+    end
+  end
+
+  describe "call!" do
+    test "returns data on success" do
+      data = call!(order_query(), variables: %{order_id: 1})
+
+      assert data.order == %{
+               id: 1,
+               order_items: [
+                 %{product_name: "product 1", quantity: 1},
+                 %{product_name: "product 2", quantity: 2}
+               ]
+             }
+    end
+
+    test "raises on failure" do
+      error = assert_raise ExUnit.AssertionError, fn -> call!(failing_query()) end
+      assert error.message =~ "GraphQL call failed"
+      assert error.message =~ "invalid login data"
+      assert error.message =~ "can't be blank"
+    end
+  end
+
+  describe "errors" do
+    test "returns all error messages" do
+      {:error, response} = call(failing_query())
+      assert errors(response) == ["invalid login data", "can't be blank"]
+    end
+  end
+
+  describe "field_errors" do
+    test "returns error messages for the desired field" do
+      {:error, response} = call(failing_query())
+      assert field_errors(response, "login") == ["can't be blank"]
+    end
+  end
+
+  defp order_query do
+    """
+    query ($order_id: Int!) {
+      order(id: $order_id) {
+        id
+        order_items {product_name quantity}
+      }
+    }
+    """
+  end
+
+  defp failing_query, do: "mutation {register_user}"
+end


### PR DESCRIPTION
## Changes

Based on experiences from dmf and banmed_wfm, I've created a helper ExUnit case template for writing GraphQL tests. To try it out in practice, I've adapted current banmed tests to the new logic. You can see the results in [this branch](https://github.com/VeryBigThings/banmed_wfm_backend/tree/migrate-to-graphql-client-from-common), but here are the main highlights:

To reduce boilerplate, you're advised to create the case template as follows:

```elixir
defmodule BanmedWeb.GraphqlCase do
  defmacro __using__(opts) do
    quote do
      use VBT.Graphql.Case,
        repo: Banmed.Repo,
        endpoint: BanmedWeb.Endpoint,
        api_path: "/api/graphql",
        async: Keyword.get(unquote(opts), :async, false)
    end
  end
end
```

Now, you can define the test module as:

```elixir
defmodule BanmedWeb.Graphql.BanmedGraphqlTest do
  use BanmedWeb.GraphqlCase, async: true
  # ...
end
```

This will make the module behave as `ConnCase` too, so there's no need to use that module separately.

Now in your tests you can issue a query as:

```elixir
input_vars = %{login: login, ...}
assert {:ok, data} = call(graphql_query, variables: input_vars)
```

On success, the result is the value of the data field, with all keys recursively converted to the underscore case and atomized. Thus, instead of using `response["data"]["someField"]`, you use `data.some_field`.

On error, the function returns `{:error, response}` where response is the root map (map containing both data and errors). You can pass this response to the `errors` and `field_errors` helpers:

```elixir
assert "some error" in errors(response)
assert "can't be blank" in field_errors(response, "login")
```

If you need to pass the authentication token, you can do it as:

```elixir
assert {:ok, data} = call(graphql_query, auth: auth_token)
```

In case you always expect success, you can invoke the bang version:

 ```elixir
token = call!(auth_query, ...).token
```


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works
