### PR TITLE
Authentication

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,5 +8,6 @@ if Mix.env() == :test do
 
   config :vbt, VBT.GraphqlServer,
     server: false,
-    secret_key_base: String.duplicate("0", 64)
+    secret_key_base: String.duplicate("0", 64),
+    pubsub: [name: VBT.PubSub, adapter: Phoenix.PubSub.PG2]
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,5 +5,8 @@ if Mix.env() == :test do
   config :phoenix, :json_library, Jason
   config :stream_data, max_runs: if(System.get_env("CI"), do: 100, else: 10)
   config :vbt, VBT.Mailer, adapter: Bamboo.TestAdapter
-  config :vbt, VBT.GraphqlServer, server: false
+
+  config :vbt, VBT.GraphqlServer,
+    server: false,
+    secret_key_base: String.duplicate("0", 64)
 end

--- a/lib/vbt/auth.ex
+++ b/lib/vbt/auth.ex
@@ -1,4 +1,66 @@
 defmodule VBT.Auth do
+  @moduledoc """
+  Helpers for implementing authentication in the UI layer (resolvers, sockets, controllers).
+
+  This module can be used to simplify the implementation of the authentication logic in
+  the web layer.
+
+  ## Using from GraphQL resolvers
+
+  Add this module as a plug in your **GraphQL pipeline**:
+
+      defmodule MyRouter do
+        pipeline :graphql_api do
+          VBT.Auth
+        end
+
+        # ...
+      end
+
+  At this point, you can invoke `sign/3` and `verify/4` from your resolvers.
+
+  It's highly recommended to introduce a helper module in your project to wrap these invocations.
+  For example:
+
+      defmodule MySystemWeb.Authentication do
+        alias VBT.Auth
+
+        @user_salt "super secret user salt"
+        @max_age :erlang.convert_time_unit(:timer.hours(24), :millisecond, :second)
+
+        def new_token(account),
+          do: Auth.sign(MySystemWeb.Endpoint, @user_salt, %{id: account.id})
+
+        def fetch_account(verifier, args \\\\ []) do
+          with {:ok, account_data} <- Auth.verify(verifier, @user_salt, @max_age, args),
+              do: load_account(account_data.id)
+        end
+
+        defp load_account(id) do
+          case MySystem.get_account(id) do
+            nil -> {:error, :account_not_found}
+            account -> {:ok, account}
+          end
+        end
+      end
+
+  ## Using from Phoenix sockets
+
+  Assuming you have the `MySystemWeb.Authentication` helper module in place, and that the input
+  is provided as `%{"authorization" => "Bearer some_token"}`:
+
+      defmodule MySystemWeb.UserSocket do
+        def connect(args, socket) do
+          case MySystemWeb.Authentication.fetch_account(socket, args) do
+            {:ok, account} -> {:ok, do_something_with(socket, account)}
+            {:error, _reason} -> :error
+          end
+        end
+
+        # ...
+      end
+  """
+
   @behaviour Plug
 
   @type salt :: String.t()
@@ -14,9 +76,11 @@ defmodule VBT.Auth do
   # API
   # ------------------------------------------------------------------------
 
+  @doc "Signs the given data using the secret from the endpoint and the provided salt."
   @spec sign(endpoint, salt, data) :: token
   def sign(endpoint, salt, data), do: Phoenix.Token.sign(endpoint, salt, data)
 
+  @doc "Verifies the signed token, returning decoded data on success."
   @spec verify(verifier, salt, non_neg_integer, args) :: {:ok, data} | {:error, verify_error}
   def verify(verifier, salt, max_age, args \\ []) do
     case Phoenix.Token.verify(endpoint(verifier), salt, token(verifier, args), max_age: max_age) do

--- a/lib/vbt/auth.ex
+++ b/lib/vbt/auth.ex
@@ -1,0 +1,71 @@
+defmodule VBT.Auth do
+  @behaviour Plug
+
+  @type salt :: String.t()
+  @type data :: any
+  @type token :: String.t()
+  @type verifier :: Plug.Conn.t() | Phoenix.Socket.t() | endpoint | Absinthe.Resolution.t()
+  @type endpoint :: module
+  @type args :: %{String.t() => arg} | [{String.t(), arg}]
+  @type arg :: String.t() | args
+  @type verify_error :: :token_missing | :token_invalid | :token_expired
+
+  # ------------------------------------------------------------------------
+  # API
+  # ------------------------------------------------------------------------
+
+  @spec sign(endpoint, salt, data) :: token
+  def sign(endpoint, salt, data), do: Phoenix.Token.sign(endpoint, salt, data)
+
+  @spec verify(verifier, salt, non_neg_integer, args) :: {:ok, data} | {:error, verify_error}
+  def verify(verifier, salt, max_age, args \\ []) do
+    case Phoenix.Token.verify(endpoint(verifier), salt, token(verifier, args), max_age: max_age) do
+      {:ok, _token} = success -> success
+      {:error, :missing} -> {:error, :token_missing}
+      {:error, :invalid} -> {:error, :token_invalid}
+      {:error, :expired} -> {:error, :token_expired}
+    end
+  end
+
+  # ------------------------------------------------------------------------
+  # Plug callbacks
+  # ------------------------------------------------------------------------
+
+  @impl Plug
+  # credo:disable-for-next-line Credo.Check.Readability.Specs
+  def init(opts), do: opts
+
+  @impl Plug
+  # credo:disable-for-next-line Credo.Check.Readability.Specs
+  def call(conn, _opts), do: Absinthe.Plug.put_options(conn, context: %{conn: conn})
+
+  # ------------------------------------------------------------------------
+  # Private
+  # ------------------------------------------------------------------------
+
+  defp token(verifier, args),
+    do: with("Bearer " <> token <- find_token(verifier, args), do: token)
+
+  defp find_token(verifier, args) do
+    tokens_from_args(args)
+    |> Stream.concat(tokens_from_header(verifier))
+    |> Enum.find(&String.starts_with?(&1, "Bearer "))
+  end
+
+  defp tokens_from_args(args) do
+    args
+    |> Stream.filter(&match?({"authorization", _}, &1))
+    |> Stream.map(fn {"authorization", value} -> value end)
+  end
+
+  defp tokens_from_header(%Phoenix.Socket{} = _socket), do: []
+
+  defp tokens_from_header(verifier),
+    do: Plug.Conn.get_req_header(conn(verifier), "authorization")
+
+  defp endpoint(%Phoenix.Socket{} = socket), do: socket.endpoint
+  defp endpoint(other), do: Phoenix.Controller.endpoint_module(conn(other))
+
+  defp conn(%Absinthe.Resolution{} = resolution), do: resolution.context.conn
+  defp conn(%Plug.Conn{} = conn), do: conn
+end

--- a/mix.exs
+++ b/mix.exs
@@ -27,9 +27,9 @@ defmodule VBT.Credo.MixProject do
       {:dialyxir, "~> 0.5", runtime: false},
       {:stream_data, "~> 0.4", only: [:test, :dev]},
       {:ecto, "~> 3.0", optional: true},
-      {:absinthe, "~> 1.4", optional: true},
+      {:absinthe, "~> 1.4"},
       {:absinthe_plug, "~> 1.4"},
-      {:phoenix, "~> 1.4", optional: true},
+      {:phoenix, "~> 1.4"},
       {:bamboo, "~> 1.0", optional: true}
     ]
   end
@@ -46,7 +46,7 @@ defmodule VBT.Credo.MixProject do
 
   defp dialyzer() do
     [
-      plt_add_apps: ~w/mix eex ecto absinthe credo bamboo phoenix ex_unit phoenix_pubsub/a
+      plt_add_apps: ~w/mix eex ecto credo bamboo ex_unit phoenix_pubsub/a
     ]
   end
 

--- a/test/integration/skafolder_tester/mix.lock
+++ b/test/integration/skafolder_tester/mix.lock
@@ -6,6 +6,9 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.4.11", "d112c862f6959f98e6e915c3b76c7a87ca3efd075850c8daa7c3c7a609014b0d", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.1", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.8.1 or ~> 1.9", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 1.0 or ~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.2", "496c303bdf1b2e98a9d26e89af5bba3ab487ba3a3735f74bf1f4064d2a845a3e", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
 }

--- a/test/support/vbt/graphql_server.ex
+++ b/test/support/vbt/graphql_server.ex
@@ -1,5 +1,7 @@
 defmodule VBT.GraphqlServer do
   @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
+
   use Phoenix.Endpoint, otp_app: :vbt
   import Phoenix.Controller, only: [accepts: 2]
   import VBT.Absinthe.ResolverHelper
@@ -75,6 +77,7 @@ defmodule VBT.GraphqlServer do
   end
 
   defmodule Socket do
+    @moduledoc false
     use Phoenix.Socket
 
     def connect(args, socket) do

--- a/test/vbt/auth_test.exs
+++ b/test/vbt/auth_test.exs
@@ -1,0 +1,33 @@
+defmodule VBT.AuthTest do
+  use VBT.Graphql.Case, async: true, endpoint: VBT.GraphqlServer, api_path: "/"
+
+  describe "GraphQL authentication" do
+    test "correctly decodes valid token" do
+      token = authenticate!("some_login")
+      assert {:ok, data} = current_user(token)
+      assert data.current_user == "some_login"
+    end
+
+    test "rejects expired token" do
+      token = authenticate!("some_login")
+      assert {:error, response} = current_user(token, max_age: 0)
+      assert "token_expired" in errors(response)
+    end
+
+    test "rejects invalid token" do
+      assert {:error, response} = current_user("invalid token")
+      assert "token_invalid" in errors(response)
+    end
+
+    test "rejects missing token" do
+      assert {:error, response} = current_user(nil)
+      assert "token_missing" in errors(response)
+    end
+  end
+
+  defp authenticate!(login),
+    do: call!(~s/query {auth_token(login: "#{login}")}/).auth_token
+
+  defp current_user(token, opts \\ []),
+    do: call(~s/query {current_user(max_age: #{opts[:max_age] || "null"})}/, auth: token)
+end

--- a/test/vbt/graphql/case_test.exs
+++ b/test/vbt/graphql/case_test.exs
@@ -21,11 +21,6 @@ defmodule VBT.Graphql.CaseTest do
       assert error1 == "invalid login data"
       assert error2 == "can't be blank"
     end
-
-    test "propagates authentication header" do
-      auth_token = Base.encode64(:crypto.strong_rand_bytes(16), padding: false)
-      assert call("query {login}", auth: auth_token) == {:ok, %{login: auth_token}}
-    end
   end
 
   describe "call!" do


### PR DESCRIPTION
## Changes

This PR adds some common helpers for implementing UI-based authentication in resolvers and sockets. In theory it should also suffice for controller-based authentication, but I haven't tried it out, so there may be a few things missing here. Current functionality supports the needs of Banmed WFM, and I believe that it should also suite the needs of the DMF project.

Compared to how auth has been implemented in these project, this code takes a bit different approach. Instead of using Absinthe middleware, this code exposes two helper functions which can be used from resolvers.

Producing the tokens is done with the function `sign`, which is a plain delegate to `Phoenix.Token.sign`.

For verifying and decoding tokens, you need to add `plug VBT.Auth` in the pipeline for GraphQL API. Then, you can simply invoke `verify(resolution, salt, max_age)` from the resolver. It's advised to wrap this in a small helper module. For concrete example, see [WFM authentication helper](https://github.com/VeryBigThings/banmed_wfm_backend/blob/adapt-authentication/lib/banmed_web/authentication.ex).

This approach means that, instead of sprinkling `middleware Middlewares.Authentication` all over the GraphQL schema, you need to explicitly invoke verification function in the resolver. Here's an example from WFM:

```elixir
def create_task_note(params, resolution) do
  with {:ok, account} <- fetch_account(resolution),
        do: Banmed.insert_task_note(params, account)
end
```

As a result, the schema is more focused on specifying the data contract, while behaviour logic is moved to resolvers. As an added bonus, we get more flexibility. For example, if you need to support a field which works both for authenticated and unauthenticated users, you can simply do:

```elixir
def resolve_field(params, resolution) do
  case fetch_account(resolution) do
    {:ok, account} -> authenticated_resolve_field(params, account)
    {:error, _} -> anonymous_resolve_field(params)
  end
end
```

Since it was needed for WFM, the logic also supports authentication from sockets. To do this, the client code has to explicitly pass args on connect:

```elixir
defmodule BanmedWeb.UserSocket do
  def connect(args, socket) do
    case Authentication.fetch_account(socket, args) do
      {:ok, account} -> {:ok, authorize_socket(socket, account)}
      {:error, _reason} -> :error
    end
  end

  # ...
end

```

The code assumes that the authorization is provided as `%{"authorization" => "Bearer some_token"}`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works