### PR TITLE
Add helpers for working with multi results

### DIFF
--- a/lib/vbt/ecto.ex
+++ b/lib/vbt/ecto.ex
@@ -1,0 +1,67 @@
+defmodule VBT.Ecto do
+  @moduledoc "Helpers for working with Ecto."
+
+  alias Ecto.Multi
+
+  @type multi_result ::
+          {:ok, changes}
+          | {:error, failed_operation :: Multi.name(), reason :: any, changes}
+
+  @type changes :: %{Multi.name() => any}
+
+  @doc """
+  Returns the result of a multi operation or the operation error.
+
+      iex> result = (
+      ...>   Ecto.Multi.new()
+      ...>   |> Ecto.Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+      ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:ok, 2} end)
+      ...>   |> Ecto.Multi.run(:baz, fn _, _ -> {:ok, 3} end)
+      ...>   |> VBT.TestRepo.transaction()
+      ...> )
+      iex> VBT.Ecto.multi_operation_result(result, :foo)
+      {:ok, 1}
+
+      iex> result = (
+      ...>   Ecto.Multi.new()
+      ...>   |> Ecto.Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+      ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:error, "bar error"} end)
+      ...>   |> VBT.TestRepo.transaction()
+      ...> )
+      iex> VBT.Ecto.multi_operation_result(result, :foo)
+      {:error, "bar error"}
+  """
+  @spec multi_operation_result(multi_result, Multi.name()) :: {:ok, any} | {:error, any}
+  def multi_operation_result(multi_result, operation),
+    do: map_multi_result(multi_result, &Map.fetch!(&1, operation))
+
+  @doc """
+  Maps the result of a multi operation, or returns an error.
+
+      iex> result = (
+      ...>   Ecto.Multi.new()
+      ...>   |> Ecto.Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+      ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:ok, 2} end)
+      ...>   |> Ecto.Multi.run(:baz, fn _, _ -> {:ok, 3} end)
+      ...>   |> VBT.TestRepo.transaction()
+      ...> )
+      iex> VBT.Ecto.map_multi_result(result, &Map.take(&1, [:foo, :bar]))
+      {:ok, %{foo: 1, bar: 2}}
+
+      iex> result = (
+      ...>   Ecto.Multi.new()
+      ...>   |> Ecto.Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+      ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:error, "bar error"} end)
+      ...>   |> VBT.TestRepo.transaction()
+      ...> )
+      iex> VBT.Ecto.map_multi_result(result, &Map.take(&1, [:foo, :bar]))
+      {:error, "bar error"}
+  """
+  @spec map_multi_result(multi_result, (changes -> result)) :: {:ok, result} | {:error, any}
+        when result: var
+  def map_multi_result({:ok, result}, success_mapper),
+    do: {:ok, success_mapper.(result)}
+
+  def map_multi_result({:error, _operation, error, _changes}, _success_mapper),
+    do: {:error, error}
+end

--- a/test/vbt/ecto_test.exs
+++ b/test/vbt/ecto_test.exs
@@ -1,0 +1,29 @@
+defmodule VBT.EctoTest do
+  use ExUnit.Case, async: true
+  doctest VBT.Ecto
+
+  import VBT.Ecto
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Ecto.Multi
+  alias VBT.TestRepo
+
+  setup do
+    Sandbox.checkout(VBT.TestRepo)
+    :ok
+  end
+
+  describe "multi_operation_result" do
+    test "raises if invalid field is accessed" do
+      result =
+        Multi.new()
+        |> Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+        |> TestRepo.transaction()
+
+      assert_raise(
+        KeyError,
+        "key :bar not found in: %{foo: 1}",
+        fn -> multi_operation_result(result, :bar) end
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Changes

This PR adds two small helpers which should help us reduce a bit of noise related to handling multi results.

The `multi_operation_result` function can be used to return the result of a particular multi operation:

```elixir
Multi.new()
|> Multi.insert(:foo, ...)
|> Multi.run(:bar, ...)
|> ...
|> Repo.transaction()
# returns {:ok, result_of_foo} | {:error, error_of_failed_operation}
|> multi_operation_result(:foo)
```

The `map_multi_result` function is a bit more general, allowing us to perform arbitrary mapping on the successful result:

```elixir
Multi.new()
|> Multi.insert(:foo, ...)
|> Multi.run(:bar, ...)
|> ...
|> Repo.transaction()
# returns {:ok, %{foo: result_of_foo, bar: result_of_bar} | {:error, error_of_failed_operation}
|> map_multi_result(&Map.take(&1, [:foo, :bar])
```

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works