### PR TITLE
Credo improvements

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -13,6 +13,7 @@
         {VBT.Credo.Check.Consistency.ModuleLayout, []},
         {VBT.Credo.Check.Readability.WithPlaceholder, []},
         {VBT.Credo.Check.Consistency.FileLocation, []},
+        {VBT.Credo.Check.Readability.MultilineSimpleDo, []},
         {Credo.Check.Readability.Specs, []},
         {Credo.Check.Design.TagTODO, false}
       ]

--- a/lib/vbt/credo/check/readability/multiline_simple_do.ex
+++ b/lib/vbt/credo/check/readability/multiline_simple_do.ex
@@ -1,0 +1,85 @@
+defmodule VBT.Credo.Check.Readability.MultilineSimpleDo do
+  @moduledoc false
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
+  # credo:disable-for-this-file VBT.Credo.Check.Readability.MultilineSimpleDo
+
+  @checkdoc """
+  Avoid using multiline simple do expression.
+
+      # preferred
+
+      defp some_fun() do
+        %{
+          a: 1,
+          b: 2,
+          c: 3
+        }
+      end
+
+      # NOT preferred
+
+      defp some_fun(),
+        do: %{
+          a: 1,
+          b: 2,
+          c: 3
+        }
+  """
+  @explanation [check: @checkdoc]
+
+  # `use Credo.Check` required that module attributes are already defined, so we need to place these attributes
+  # before use/alias expressions.
+  # credo:disable-for-next-line VBT.Credo.Check.Consistency.ModuleLayout
+  use Credo.Check, category: :warning, base_priority: :high
+
+  def run(source_file, params \\ []) do
+    source_file
+    |> lines()
+    |> multiline_simple_dos()
+    |> Enum.map(&credo_error(&1, IssueMeta.for(source_file, params)))
+  end
+
+  defp lines(source_file) do
+    source_file
+    |> Credo.SourceFile.lines()
+    |> Stream.map(&with_location/1)
+    |> Stream.reject(&(&1.content =~ ~r/^#/))
+  end
+
+  defp with_location({row, content}) do
+    column =
+      case Regex.run(~r/^\s*./, content, return: :index) do
+        [{0, column}] -> column
+        nil -> 0
+      end
+
+    %{row: row, column: column, content: String.trim(content)}
+  end
+
+  defp multiline_simple_dos(lines) do
+    lines
+    |> Stream.chunk_every(3, 1, :discard)
+    |> Stream.map(fn [previous_line, this_line, next_line] ->
+      # Recognition algorithm:
+      #   1. Previous line ends with `,`
+      #   2. This line starts with `do:`
+      #   3. Next line is not empty, `end`, `)`, or `else:`
+      if previous_line.content =~ ~r/^.*,$/ and
+           String.starts_with?(this_line.content, "do:") and
+           not (next_line.content == "" or
+                  next_line.content in ~w/end ) end) " """/ or
+                  String.starts_with?(next_line.content, "else:")),
+         do: this_line
+    end)
+    |> Stream.reject(&is_nil/1)
+  end
+
+  defp credo_error(line, issue_meta) do
+    format_issue(
+      issue_meta,
+      message: "Replace multiline `do:` expression with `do...end`",
+      line_no: line.row,
+      column: line.column
+    )
+  end
+end

--- a/lib/vbt/credo/module_part_extractor.ex
+++ b/lib/vbt/credo/module_part_extractor.ex
@@ -1,5 +1,5 @@
 defmodule VBT.Credo.ModulePartExtractor do
-  @moduledoc "Extraction of module parts from an ast"
+  @moduledoc false
 
   @type module_part ::
           :moduledoc
@@ -26,110 +26,6 @@ defmodule VBT.Credo.ModulePartExtractor do
           | :impl
   @type location :: [line: pos_integer, column: pos_integer]
 
-  @doc """
-  Extracts modules and their parts from the AST obtained from an Elixir source file.
-
-  iex> {:ok, ast} = Code.string_to_quoted(~s/
-  ...>   defmodule SomeModule do
-  ...>     @moduledoc "Some module doc"
-  ...>
-  ...>     @behaviour GenServer
-  ...>
-  ...>     use GenServer
-  ...>
-  ...>     import GenServer
-  ...>
-  ...>     alias GenServer
-  ...>     alias Mod1.{Mod2, Mod3}
-  ...>
-  ...>     require GenServer
-  ...>
-  ...>     @x 1
-  ...>
-  ...>     defstruct a: 1, b: 2
-  ...>
-  ...>     @opaque y :: pos_integer
-  ...>     @type x :: pos_integer
-  ...>     @typep z :: pos_integer
-  ...>
-  ...>     @callback callback() :: any
-  ...>
-  ...>     @macrocallback macrocallback() :: any
-  ...>
-  ...>     @optional_callbacks [callback: 0]
-  ...>
-  ...>     def public_fun(), do: :ok
-  ...>
-  ...>     @impl true
-  ...>     def callback_fun(), do: :ok
-  ...>
-  ...>     @impl GenServer
-  ...>     def callback_fun(), do: :ok
-  ...>
-  ...>     @doc false
-  ...>     def private_fun(), do: :ok
-  ...>
-  ...>     defp another_private_fun(), do: :ok
-  ...>
-  ...>     defmacro public_macro(), do: :ok
-  ...>
-  ...>     @impl true
-  ...>     defmacro callback_fun(), do: :ok
-  ...>
-  ...>     @impl GenServer
-  ...>     defmacro callback_fun(), do: :ok
-  ...>
-  ...>     @doc false
-  ...>     defmacro private_macro(), do: :ok
-  ...>
-  ...>     defmacrop another_private_macro(), do: :ok
-  ...>
-  ...>     defguard public_guard(), do: :ok
-  ...>
-  ...>     @doc false
-  ...>     defguard private_guard(), do: :ok
-  ...>
-  ...>     defguardp another_private_guard(), do: :ok
-  ...>   end
-  ...>
-  ...>   defmodule AnotherModule do
-  ...>     @moduledoc "Another module doc"
-  ...>   end
-  ...> /)
-  iex> VBT.Credo.ModulePartExtractor.analyze(ast)
-  [
-    {SomeModule, [
-      moduledoc: [line: 3],
-      behaviour: [line: 5],
-      use: [line: 7],
-      import: [line: 9],
-      alias: [line: 11],
-      alias: [line: 12],
-      require: [line: 14],
-      module_attribute: [line: 16],
-      defstruct: [line: 18],
-      opaque: [line: 20],
-      type: [line: 21],
-      typep: [line: 22],
-      callback: [line: 24],
-      macrocallback: [line: 26],
-      optional_callbacks: [line: 28],
-      public_fun: [line: 30],
-      impl: [line: 33],
-      impl: [line: 36],
-      private_fun: [line: 39],
-      private_fun: [line: 41],
-      public_macro: [line: 43],
-      impl: [line: 46],
-      impl: [line: 49],
-      private_macro: [line: 52],
-      private_macro: [line: 54],
-      public_guard: [line: 56],
-      private_guard: [line: 59]
-    ]},
-    {AnotherModule, [moduledoc: [line: 65]]}
-  ]
-  """
   @spec analyze(Macro.t()) :: [{module, [{module_part, location}]}]
   def analyze(ast) do
     {_ast, state} = Macro.prewalk(ast, initial_state(), &traverse_file/2)

--- a/test/vbt/credo/check/readability/multiline_simple_do_test.exs
+++ b/test/vbt/credo/check/readability/multiline_simple_do_test.exs
@@ -1,0 +1,87 @@
+defmodule VBT.Credo.Check.Readability.MultilineSimpleDoTest do
+  # credo:disable-for-this-file VBT.Credo.Check.Readability.MultilineSimpleDo
+  use Credo.TestHelper
+
+  @described_check VBT.Credo.Check.Readability.MultilineSimpleDo
+
+  test "reports no errors on valid usage" do
+    """
+    defmodule Test do
+      def fun1, do: :ok
+      def fun2, do: :ok
+
+      def fun3,
+        do: :ok
+
+      def fun4 do
+        if some_condition(),
+          do: :ok,
+          else: :error
+      end
+    end
+    """
+    |> to_source_file()
+    |> refute_issues(@described_check)
+  end
+
+  test "reports error on multiline do:" do
+    [issue] =
+      """
+      defmodule Test do
+        def fun,
+          do:
+            :ok
+      end
+      """
+      |> to_source_file()
+      |> assert_issue(@described_check)
+
+    assert issue.line_no == 3
+    assert issue.column == 5
+  end
+
+  test "reports error with comments present:" do
+    [issue] =
+      """
+      defmodule Test do
+        def fun,
+          # some comment
+          do:
+          # another comment
+            :ok
+      end
+      """
+      |> to_source_file()
+      |> assert_issue(@described_check)
+
+    assert issue.line_no == 4
+    assert issue.column == 5
+  end
+
+  test "reports multiple errors" do
+    assert [issue1, issue2] =
+             """
+             defmodule Test do
+               def fun1,
+                 do:
+                   :ok
+
+               def fun2, do: :ok
+
+               def fun3,
+                 # some comment
+                 do:
+                 # another comment
+                   :ok
+             end
+             """
+             |> to_source_file()
+             |> assert_issues(@described_check)
+
+    assert issue1.line_no == 3
+    assert issue1.column == 5
+
+    assert issue2.line_no == 10
+    assert issue2.column == 5
+  end
+end


### PR DESCRIPTION
## Changes

Adds a credo check for "multiline simple do expressions". When enabled, this check reports occurrences of:

```elixir
def foo(),
  do: %{
    a: 1,
    b: 2,
    # ...
  }
```

The implementation is somewhat fragile, since it's based on regexes, but it seems to be working fine. I tried it out on banmed_wfm, banmed_telehealth, and dmf, and it discovered a few instances, while not producing any false positives.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works
