### PR TITLE
Use default mapper in `map_multi_result`

### DIFF
--- a/lib/vbt/ecto.ex
+++ b/lib/vbt/ecto.ex
@@ -45,6 +45,16 @@ defmodule VBT.Ecto do
       ...>   |> Ecto.Multi.run(:baz, fn _, _ -> {:ok, 3} end)
       ...>   |> VBT.TestRepo.transaction()
       ...> )
+      iex> VBT.Ecto.map_multi_result(result)
+      {:ok, %{foo: 1, bar: 2, baz: 3}}
+
+      iex> result = (
+      ...>   Ecto.Multi.new()
+      ...>   |> Ecto.Multi.run(:foo, fn _, _ -> {:ok, 1} end)
+      ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:ok, 2} end)
+      ...>   |> Ecto.Multi.run(:baz, fn _, _ -> {:ok, 3} end)
+      ...>   |> VBT.TestRepo.transaction()
+      ...> )
       iex> VBT.Ecto.map_multi_result(result, &Map.take(&1, [:foo, :bar]))
       {:ok, %{foo: 1, bar: 2}}
 
@@ -54,11 +64,13 @@ defmodule VBT.Ecto do
       ...>   |> Ecto.Multi.run(:bar, fn _, _ -> {:error, "bar error"} end)
       ...>   |> VBT.TestRepo.transaction()
       ...> )
-      iex> VBT.Ecto.map_multi_result(result, &Map.take(&1, [:foo, :bar]))
+      iex> VBT.Ecto.map_multi_result(result)
       {:error, "bar error"}
   """
   @spec map_multi_result(multi_result, (changes -> result)) :: {:ok, result} | {:error, any}
         when result: var
+  def map_multi_result(multi_result, success_mapper \\ & &1)
+
   def map_multi_result({:ok, result}, success_mapper),
     do: {:ok, success_mapper.(result)}
 


### PR DESCRIPTION
## Changes

As proposed [here](https://github.com/VeryBigThings/banmed_wfm_backend/pull/119#pullrequestreview-345863636), I added a default `& &1` success mapper to `map_multi_result`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
