### PR TITLE
Deduce foreign key name via reflection

### DIFF
--- a/lib/vbt/accounts/token.ex
+++ b/lib/vbt/accounts/token.ex
@@ -123,7 +123,7 @@ defmodule VBT.Accounts.Token do
            from(
              token in config.schemas.token,
              where: token.id == ^token.id,
-             where: field(token, ^account_id_field_name(account)) == ^account.id,
+             where: field(token, ^account_id_field_name(config)) == ^account.id,
              where: is_nil(token.used_at),
              where: token.expires_at >= ^now
            ),
@@ -134,8 +134,18 @@ defmodule VBT.Accounts.Token do
     end
   end
 
-  defp account_id_field_name(account),
-    do: account.__meta__.schema.__schema__(:association, :tokens).related_key
+  defp account_id_field_name(config) do
+    account_schema = config.schemas.account
+
+    # Using Ecto schema reflection (https://hexdocs.pm/ecto/Ecto.Schema.html#module-reflection)
+    # to fetch meta about the `:tokens` association.
+    tokens_meta = account_schema.__schema__(:association, :tokens)
+
+    # Since `:tokens` is `has_many`, `tokens_meta` is an instance of `Ecto.Association.Has`
+    # (https://hexdocs.pm/ecto/Ecto.Association.Has.html). The field `related_key` in this
+    # struct contains the name of the column in the tokens table.
+    tokens_meta.related_key
+  end
 
   # ------------------------------------------------------------------------
   # Periodic cleanup

--- a/lib/vbt/accounts/token.ex
+++ b/lib/vbt/accounts/token.ex
@@ -123,7 +123,7 @@ defmodule VBT.Accounts.Token do
            from(
              token in config.schemas.token,
              where: token.id == ^token.id,
-             where: token.account_id == ^account.id,
+             where: field(token, ^account_id_field_name(account)) == ^account.id,
              where: is_nil(token.used_at),
              where: token.expires_at >= ^now
            ),
@@ -133,6 +133,9 @@ defmodule VBT.Accounts.Token do
       _ -> {:error, :invalid}
     end
   end
+
+  defp account_id_field_name(account),
+    do: account.__meta__.schema.__schema__(:association, :tokens).related_key
 
   # ------------------------------------------------------------------------
   # Periodic cleanup


### PR DESCRIPTION
## Changes
Previously the foreign key name was hardcoded, forcing the client code to name the field `account_id`. This PR fixes this, so clients can use arbitrary names for foreign keys. For demonstration, see [this upcoming commit in banmed_telehealth](https://github.com/VeryBigThings/banmed-telehealth-backend/commit/c8e03af7cdfaeaf9f121cd6c80407cef1ce9fd7d)

## Checklist:
- [x] I have performed a self-review of my own code
