### PR TITLE
Runtime config

### DIFF
--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -73,6 +73,14 @@ defmodule VBT.Provider do
   conditionally define the function only in required mix env, by moving the function definition
   under an `if Mix.env() == ` conditional.
 
+  ## Generating template
+
+  The config module will contain the `template/0` function which generates the configuration
+  template. To print the template to stdout, you can invoke:
+
+      MIX_ENV=prod mix compile
+      MIX_ENV=prod mix run --no-start -e 'IO.puts(MySystem.Config.template())'
+
   ## Lower level API
 
   The foundational retrieval functionality is available via functions of this module, such as
@@ -224,6 +232,12 @@ defmodule VBT.Provider do
           end
         end
       )
+
+      @doc "Returns a template configuration file."
+      @spec template :: String.t()
+      def template do
+        unquote(Keyword.fetch!(spec, :source)).template(%{unquote_splicing(quoted_params)})
+      end
     end
   end
 
@@ -255,6 +269,7 @@ defmodule VBT.Provider do
 
   defmodule Source do
     @moduledoc "Contract for storage sources."
+    alias VBT.Provider
 
     @doc """
     Invoked to provide the values for the given parameters.
@@ -262,9 +277,12 @@ defmodule VBT.Provider do
     This function should return all values in the requested orders. For each param which is not
     available, `nil` should be returned.
     """
-    @callback values([VBT.Provider.param_name()]) :: [VBT.Provider.value()]
+    @callback values([Provider.param_name()]) :: [Provider.value()]
 
     @doc "Invoked to convert the param name to storage specific name."
-    @callback display_name(VBT.Provider.param_name()) :: String.t()
+    @callback display_name(Provider.param_name()) :: String.t()
+
+    @doc "Invoked to create operator template."
+    @callback template(Provider.params()) :: String.t()
   end
 end

--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -1,0 +1,74 @@
+defmodule VBT.Provider do
+  alias Ecto.Changeset
+
+  @type adapter :: module
+  @type params :: %{param_name => param_spec}
+  @type param_name :: atom
+  @type param_spec :: %{type: type, default: value}
+  @type type :: :string | :integer | :float | :boolean
+  @type value :: String.t() | number | boolean | nil
+  @type data :: %{param_name => value}
+
+  # ------------------------------------------------------------------------
+  # API
+  # ------------------------------------------------------------------------
+
+  @spec fetch_all(adapter, params) :: {:ok, data} | {:error, [String.t()]}
+  def fetch_all(adapter, params) do
+    types = Enum.into(params, %{}, fn {name, spec} -> {name, spec.type} end)
+
+    data =
+      params
+      |> Stream.zip(adapter.values(Map.keys(types)))
+      |> Enum.into(%{}, fn {{param, opts}, provided_value} ->
+        value = if is_nil(provided_value), do: opts.default, else: provided_value
+        {param, value}
+      end)
+
+    {%{}, types}
+    |> Changeset.cast(data, Map.keys(types))
+    |> Changeset.validate_required(Map.keys(types), message: "is missing")
+    |> case do
+      %Changeset{valid?: true} = changeset -> {:ok, Changeset.apply_changes(changeset)}
+      %Changeset{valid?: false} = changeset -> {:error, changeset_error(adapter, changeset)}
+    end
+  end
+
+  @spec fetch_one(adapter, param_name, param_spec) :: {:ok, value} | {:error, [String.t()]}
+  def fetch_one(adapter, param_name, param_spec) do
+    with {:ok, map} <- fetch_all(adapter, %{param_name => param_spec}),
+         do: {:ok, Map.fetch!(map, param_name)}
+  end
+
+  @spec fetch_one!(adapter, param_name, param_spec) :: value
+  def fetch_one!(adapter, param, param_spec) do
+    case fetch_one(adapter, param, param_spec) do
+      {:ok, value} -> value
+      {:error, errors} -> raise Enum.join(errors, ", ")
+    end
+  end
+
+  # ------------------------------------------------------------------------
+  # Private
+  # ------------------------------------------------------------------------
+
+  defp changeset_error(adapter, changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      Enum.reduce(
+        opts,
+        msg,
+        fn {key, value}, acc -> String.replace(acc, "%{#{key}}", to_string(value)) end
+      )
+    end)
+    |> Enum.flat_map(fn {key, errors} ->
+      Enum.map(errors, &"#{adapter.display_name(key)} #{&1}")
+    end)
+    |> Enum.sort()
+  end
+
+  defmodule Adapter do
+    @callback values([VBT.Provider.param_name()]) :: [VBT.Provider.value()]
+    @callback display_name(VBT.Provider.param_name()) :: String.t()
+  end
+end

--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -67,6 +67,103 @@ defmodule VBT.Provider do
     |> Enum.sort()
   end
 
+  @doc false
+  defmacro __using__(spec) do
+    spec =
+      update_in(
+        spec[:params],
+        fn params -> Enum.map(params, &normalize_param_spec(&1, Mix.env())) end
+      )
+
+    quote bind_quoted: [spec: spec] do
+      # Generate typespec mapping for each param
+      typespecs =
+        Enum.map(
+          Keyword.fetch!(spec, :params),
+          fn {param_name, param_spec} ->
+            type =
+              case Keyword.fetch!(param_spec, :type) do
+                :integer -> quote(do: integer())
+                :boolean -> quote(do: boolean())
+                :string -> quote(do: String.t())
+              end
+
+            {param_name, type}
+          end
+        )
+
+      # Convert each param's spec into a quoted map. This is done so we can inject the map
+      # with constants direcly into the function definition. In other words, this ensures that
+      # we converted the input keyword list into a map at compile time, not runtime.
+      quoted_params =
+        spec
+        |> Keyword.fetch!(:params)
+        |> Enum.map(fn {name, spec} -> {name, quote(do: %{unquote_splicing(spec)})} end)
+
+      @spec fetch_all :: {:ok, %{unquote_splicing(typespecs)}} | {:error, [String.t()]}
+      def fetch_all do
+        VBT.Provider.fetch_all(
+          unquote(Keyword.fetch!(spec, :adapter)),
+
+          # quoted_params is itself a keyword list, so we need to convert it into a map
+          %{unquote_splicing(quoted_params)}
+        )
+      end
+
+      @spec validate!() :: :ok
+      def validate!() do
+        with {:error, errors} <- fetch_all() do
+          raise "Following OS env var errors were found:\n#{Enum.join(Enum.sort(errors), "\n")}"
+        end
+
+        :ok
+      end
+
+      # Generate getter for each param.
+      Enum.each(
+        quoted_params,
+        fn {param_name, param_spec} ->
+          @spec unquote(param_name)() :: unquote(Keyword.fetch!(typespecs, param_name))
+          # bug in credo spec check
+          # credo:disable-for-next-line Credo.Check.Readability.Specs
+          def unquote(param_name)() do
+            VBT.Provider.fetch_one!(
+              unquote(Keyword.fetch!(spec, :adapter)),
+              unquote(param_name),
+              unquote(param_spec)
+            )
+          end
+        end
+      )
+    end
+  end
+
+  defp normalize_param_spec(param_name, mix_env) when is_atom(param_name),
+    do: normalize_param_spec({param_name, []}, mix_env)
+
+  defp normalize_param_spec({param_name, param_spec}, mix_env) do
+    default_keys =
+      case mix_env do
+        :test -> [:test, :dev, :default]
+        :dev -> [:dev, :default]
+        :prod -> [:default]
+      end
+
+    default_value =
+      default_keys
+      |> Stream.map(&Keyword.get(param_spec, &1))
+      |> Enum.find(&(not is_nil(&1)))
+
+      # We need to escape to make sure that default of e.g. `foo()` is correctly passed to
+      # `__using__` quote block and properly resolved as a runtime function call.
+      #
+      # The `unquote: true` option ensures that default of `unquote(foo)` is resolved in the
+      # context of the client module.
+      |> Macro.escape(unquote: true)
+
+    {param_name, [type: Keyword.get(param_spec, :type, :string), default: default_value]}
+  end
+
   defmodule Adapter do
     @callback values([VBT.Provider.param_name()]) :: [VBT.Provider.value()]
     @callback display_name(VBT.Provider.param_name()) :: String.t()

--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -178,6 +178,7 @@ defmodule VBT.Provider do
             type =
               case Keyword.fetch!(param_spec, :type) do
                 :integer -> quote(do: integer())
+                :float -> quote(do: float())
                 :boolean -> quote(do: boolean())
                 :string -> quote(do: String.t())
               end

--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -126,7 +126,7 @@ defmodule VBT.Provider do
     end
   end
 
-  @doc "Retrieves a single paparameters."
+  @doc "Retrieves a single parameter."
   @spec fetch_one(source, param_name, param_spec) :: {:ok, value} | {:error, [String.t()]}
   def fetch_one(source, param_name, param_spec) do
     with {:ok, map} <- fetch_all(source, %{param_name => param_spec}),

--- a/lib/vbt/provider.ex
+++ b/lib/vbt/provider.ex
@@ -1,4 +1,87 @@
 defmodule VBT.Provider do
+  @moduledoc """
+  Retrieval of configuration settings from external sources, such as OS env vars.
+
+  This module is an alternative to app env for retrieval of configuration settings. It allows you
+  to properly consolidate system settings, define per-env defaults, add strong typing, and
+  compile time guarantees.
+
+  ## Basic example
+
+      defmodule MySystem.Config do
+        use VBT.Provider,
+          adapter: VBT.Provider.SystemEnv,
+          params: [
+            {:db_host, dev: "localhost"},
+            {:db_name, dev: "my_db_dev", test: "my_db_test"},
+            {:db_pool_size, type: :integer, default: 10},
+            # ...
+          ]
+      end
+
+  This will generate the following functions in the module:
+
+    - `fetch_all` - retrieves values of all parameters
+    - `validate!` - validates that all parameters are correctly provided
+    - `db_host`, `db_name`, `db_pool_size`, ... - getter of each declared parameter
+
+  ## Describing params
+
+  Each param is described in the shape of `{param_name, param_spec}`, where `param_name` is an
+  atom, and `param_spec` is a keyword list. Providing only `param_name` (without a tuple), is the
+  same as `{param_name, []}`.
+
+  The following keys can be used in the `param_spec`:
+
+  - `:type` - Param type (see `t:type/0`). Defaults to `:string`.
+  - `:default` - Default value used if the param is not provided. Defaults to `nil` (no default).
+  - `:dev` - Default value in `:dev` and `:test` mix env. Defaults to `nil` (no default).
+  - `:test` - Default value in `:test` mix env. Defaults to `nil` (no default).
+
+  Default options are considered in the following order:
+
+  1. `:test` (if mix env is `:test`)
+  2. `:dev` (if mix env is either `:dev` or `:test`)
+  3. `:default`
+
+  For example, if `:test` and `:default` options are given, the `:test` value will be used as a
+  default in `:test` env, while `:default` will be used in all other envs.
+
+  When you invoke the generated functions, values will be retrieved from the external storage
+  (e.g. OS env). If some value is not available, a default value will be used (if provided). The
+  values are then casted according to the parameter type.
+
+  Each default can be a constant, but it can also be an expression, which is evaluated at runtime.
+  For example:
+
+      defmodule MySystem.Config do
+        use VBT.Provider,
+          adapter: VBT.Provider.SystemEnv,
+          params: [
+            # db_name/0 will be invoked when you try to retrieve this parameter (or all parameters)
+            {:db_name, dev: db_name()},
+            # ...
+          ]
+
+        defp db_name(), do: #...
+      end
+
+  It's worth noting that `VBT.Provider` performs compile-time purging of needless defaults. When you
+  compile the code in `:prod`, `:dev` and `:test` defaults will not be included in the binaries.
+  Consequently, any private function invoked only in dev/test will also not be invoked, and you'll
+  get a compiler warning when compiling the code in prod. To eliminate such warnings, you can
+  conditionally define the function only in required mix env, by moving the function definition
+  under an `if Mix.env() == ` conditional.
+
+  ## Lower level API
+
+  The foundational retrieval functionality is available via functions of this module, such as
+  `fetch_all/2`, or `fetch_one/2`. These functions are a lower level plumbing API which is less
+  convenient to use, but more flexible. Most of the time the `use`-based interface will serve you
+  better, but if you have some more involved needs which are not covered by that, you can reach
+  for these functions.
+  """
+
   alias Ecto.Changeset
 
   @type adapter :: module
@@ -13,6 +96,7 @@ defmodule VBT.Provider do
   # API
   # ------------------------------------------------------------------------
 
+  @doc "Retrieves all params according to the given specification."
   @spec fetch_all(adapter, params) :: {:ok, data} | {:error, [String.t()]}
   def fetch_all(adapter, params) do
     types = Enum.into(params, %{}, fn {name, spec} -> {name, spec.type} end)
@@ -34,12 +118,14 @@ defmodule VBT.Provider do
     end
   end
 
+  @doc "Retrieves a single paparameters."
   @spec fetch_one(adapter, param_name, param_spec) :: {:ok, value} | {:error, [String.t()]}
   def fetch_one(adapter, param_name, param_spec) do
     with {:ok, map} <- fetch_all(adapter, %{param_name => param_spec}),
          do: {:ok, Map.fetch!(map, param_name)}
   end
 
+  @doc "Retrieves a single param, raising if the value is not available."
   @spec fetch_one!(adapter, param_name, param_spec) :: value
   def fetch_one!(adapter, param, param_spec) do
     case fetch_one(adapter, param, param_spec) do
@@ -100,6 +186,7 @@ defmodule VBT.Provider do
         |> Keyword.fetch!(:params)
         |> Enum.map(fn {name, spec} -> {name, quote(do: %{unquote_splicing(spec)})} end)
 
+      @doc "Retrieves all parameters."
       @spec fetch_all :: {:ok, %{unquote_splicing(typespecs)}} | {:error, [String.t()]}
       def fetch_all do
         VBT.Provider.fetch_all(
@@ -110,6 +197,7 @@ defmodule VBT.Provider do
         )
       end
 
+      @doc "Validates all parameters, raising if some values are missing or invalid."
       @spec validate!() :: :ok
       def validate!() do
         with {:error, errors} <- fetch_all() do
@@ -124,6 +212,7 @@ defmodule VBT.Provider do
         quoted_params,
         fn {param_name, param_spec} ->
           @spec unquote(param_name)() :: unquote(Keyword.fetch!(typespecs, param_name))
+          @doc "Returns the value of the `#{param_name}` param, raising on error."
           # bug in credo spec check
           # credo:disable-for-next-line Credo.Check.Readability.Specs
           def unquote(param_name)() do
@@ -165,7 +254,17 @@ defmodule VBT.Provider do
   end
 
   defmodule Adapter do
+    @moduledoc "Contract for storage adapters."
+
+    @doc """
+    Invoked to provide the values for the given parameters.
+
+    This function should return all values in the requested orders. For each param which is not
+    available, `nil` should be returned.
+    """
     @callback values([VBT.Provider.param_name()]) :: [VBT.Provider.value()]
+
+    @doc "Invoked to convert the param name to storage specific name."
     @callback display_name(VBT.Provider.param_name()) :: String.t()
   end
 end

--- a/lib/vbt/provider/system_env.ex
+++ b/lib/vbt/provider/system_env.ex
@@ -1,11 +1,35 @@
 defmodule VBT.Provider.SystemEnv do
   # credo:disable-for-this-file Credo.Check.Readability.Specs
   @moduledoc "Provider source which retrieves values from OS env vars."
-  @behaviour VBT.Provider.Source
 
-  @impl VBT.Provider.Source
+  @behaviour VBT.Provider.Source
+  alias VBT.Provider.Source
+
+  @impl Source
   def display_name(param_name), do: param_name |> Atom.to_string() |> String.upcase()
 
-  @impl VBT.Provider.Source
+  @impl Source
   def values(param_names), do: Enum.map(param_names, &System.get_env(display_name(&1)))
+
+  @impl Source
+  def template(params) do
+    params
+    |> Enum.sort()
+    |> Enum.map(&param_entry/1)
+    |> Enum.join("\n")
+  end
+
+  defp param_entry({name, %{default: nil} = spec}) do
+    """
+    # #{spec.type}
+    #{display_name(name)}=
+    """
+  end
+
+  defp param_entry({name, spec}) do
+    """
+    # #{spec.type}
+    # #{display_name(name)}=#{spec.default}
+    """
+  end
 end

--- a/lib/vbt/provider/system_env.ex
+++ b/lib/vbt/provider/system_env.ex
@@ -1,0 +1,9 @@
+defmodule VBT.Provider.SystemEnv do
+  @behaviour VBT.Provider.Adapter
+
+  @impl VBT.Provider.Adapter
+  def display_name(param_name), do: param_name |> Atom.to_string() |> String.upcase()
+
+  @impl VBT.Provider.Adapter
+  def values(param_names), do: Enum.map(param_names, &System.get_env(display_name(&1)))
+end

--- a/lib/vbt/provider/system_env.ex
+++ b/lib/vbt/provider/system_env.ex
@@ -1,11 +1,11 @@
 defmodule VBT.Provider.SystemEnv do
   # credo:disable-for-this-file Credo.Check.Readability.Specs
-  @moduledoc "Provider storage adapter which retrieves values from OS env vars."
-  @behaviour VBT.Provider.Adapter
+  @moduledoc "Provider source which retrieves values from OS env vars."
+  @behaviour VBT.Provider.Source
 
-  @impl VBT.Provider.Adapter
+  @impl VBT.Provider.Source
   def display_name(param_name), do: param_name |> Atom.to_string() |> String.upcase()
 
-  @impl VBT.Provider.Adapter
+  @impl VBT.Provider.Source
   def values(param_names), do: Enum.map(param_names, &System.get_env(display_name(&1)))
 end

--- a/lib/vbt/provider/system_env.ex
+++ b/lib/vbt/provider/system_env.ex
@@ -1,4 +1,6 @@
 defmodule VBT.Provider.SystemEnv do
+  # credo:disable-for-this-file Credo.Check.Readability.Specs
+  @moduledoc "Provider storage adapter which retrieves values from OS env vars."
   @behaviour VBT.Provider.Adapter
 
   @impl VBT.Provider.Adapter

--- a/test/vbt/provider_test.exs
+++ b/test/vbt/provider_test.exs
@@ -172,6 +172,26 @@ defmodule VBT.ProviderTest do
     test "access function raises for on error" do
       assert_raise RuntimeError, "OPT_1 is missing", fn -> TestModule.opt_1() end
     end
+
+    test "template/0 generates config template" do
+      assert TestModule.template() ==
+               """
+               # string
+               OPT_1=
+
+               # integer
+               OPT_2=
+
+               # string
+               # OPT_3=foo
+
+               # string
+               # OPT_4=bar
+
+               # string
+               # OPT_5=baz
+               """
+    end
   end
 
   defp param_spec(overrides \\ []) do

--- a/test/vbt/provider_test.exs
+++ b/test/vbt/provider_test.exs
@@ -2,6 +2,7 @@ defmodule VBT.ProviderTest do
   use ExUnit.Case, async: true
   import VBT.TestHelper
   alias VBT.Provider
+  alias VBT.ProviderTest.TestModule
 
   describe "fetch_one" do
     test "returns correct value" do
@@ -125,26 +126,6 @@ defmodule VBT.ProviderTest do
     end
   end
 
-  defmodule TestModule do
-    baz = "baz"
-
-    use Provider,
-      adapter: Provider.SystemEnv,
-      params: [
-        :opt_1,
-        {:opt_2, type: :integer},
-        {:opt_3, default: "foo"},
-
-        # runtime resolving of the default value
-        {:opt_4, default: bar()},
-
-        # compile-time resolving of the default value
-        {:opt_5, default: unquote(baz)}
-      ]
-
-    defp bar, do: "bar"
-  end
-
   describe "generated module" do
     setup do
       Enum.each(1..5, &System.delete_env("OPT_#{&1}"))
@@ -201,4 +182,24 @@ defmodule VBT.ProviderTest do
   end
 
   defp error(param, message), do: "#{param.os_env_name} #{message}"
+
+  defmodule TestModule do
+    baz = "baz"
+
+    use Provider,
+      source: Provider.SystemEnv,
+      params: [
+        :opt_1,
+        {:opt_2, type: :integer},
+        {:opt_3, default: "foo"},
+
+        # runtime resolving of the default value
+        {:opt_4, default: bar()},
+
+        # compile-time resolving of the default value
+        {:opt_5, default: unquote(baz)}
+      ]
+
+    defp bar, do: "bar"
+  end
 end

--- a/test/vbt/provider_test.exs
+++ b/test/vbt/provider_test.exs
@@ -1,0 +1,136 @@
+defmodule VBT.ProviderTest do
+  use ExUnit.Case, async: true
+  import VBT.TestHelper
+  alias VBT.Provider
+
+  describe "fetch_one" do
+    test "returns correct value" do
+      param = param_spec()
+      System.put_env(param.os_env_name, "some value")
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, "some value"}
+    end
+
+    test "returns default value if OS env is not set" do
+      param = param_spec(default: "default value")
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) ==
+               {:ok, "default value"}
+    end
+
+    test "ignores default value and returns OS env value if it's available" do
+      param = param_spec(default: "default value")
+      System.put_env(param.os_env_name, "os env value")
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) ==
+               {:ok, "os env value"}
+    end
+
+    test "converts to integer" do
+      param = param_spec(type: :integer, default: 123)
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, 123}
+
+      System.put_env(param.os_env_name, "456")
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, 456}
+    end
+
+    test "converts to float" do
+      param = param_spec(type: :float, default: 3.14)
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, 3.14}
+
+      System.put_env(param.os_env_name, "2.72")
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, 2.72}
+    end
+
+    test "converts to boolean" do
+      param = param_spec(type: :boolean, default: true)
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, true}
+
+      System.put_env(param.os_env_name, "false")
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) == {:ok, false}
+    end
+
+    test "reports error on missing value" do
+      param = param_spec()
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) ==
+               {:error, [error(param, "is missing")]}
+    end
+
+    test "empty string is treated as a missing value" do
+      param = param_spec()
+      System.put_env(param.os_env_name, "")
+
+      assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) ==
+               {:error, [error(param, "is missing")]}
+    end
+
+    for type <- ~w/integer float boolean/a do
+      test "reports error on #{type} conversion" do
+        param = param_spec(type: unquote(type), default: 123)
+        System.put_env(param.os_env_name, "invalid value")
+
+        assert Provider.fetch_one(Provider.SystemEnv, param.name, param.opts) ==
+                 {:error, [error(param, "is invalid")]}
+      end
+    end
+  end
+
+  describe "fetch_one!" do
+    test "returns correct value" do
+      param = param_spec()
+      System.put_env(param.os_env_name, "some value")
+      assert Provider.fetch_one!(Provider.SystemEnv, param.name, param.opts) == "some value"
+    end
+
+    test "returns default value if OS env is not set" do
+      param = param_spec()
+
+      assert_raise(
+        RuntimeError,
+        "#{param.os_env_name} is missing",
+        fn -> Provider.fetch_one!(Provider.SystemEnv, param.name, param.opts) end
+      )
+    end
+  end
+
+  describe "fetch_all" do
+    test "returns correct values" do
+      param1 = param_spec()
+      param2 = param_spec(type: :integer)
+      param3 = param_spec(type: :float, default: 3.14)
+
+      System.put_env(param1.os_env_name, "some value")
+      System.put_env(param2.os_env_name, "42")
+
+      params = Enum.into([param1, param2, param3], %{}, &{&1.name, &1.opts})
+
+      assert Provider.fetch_all(Provider.SystemEnv, params) ==
+               {:ok, %{param1.name => "some value", param2.name => 42, param3.name => 3.14}}
+    end
+
+    test "reports errors" do
+      param1 = param_spec()
+      param2 = param_spec(type: :integer, default: 42)
+      param3 = param_spec(type: :float)
+
+      System.put_env(param3.os_env_name, "invalid value")
+
+      params = Enum.into([param1, param2, param3], %{}, &{&1.name, &1.opts})
+
+      assert Provider.fetch_all(Provider.SystemEnv, params) ==
+               {:error, Enum.sort([error(param1, "is missing"), error(param3, "is invalid")])}
+    end
+  end
+
+  defp param_spec(overrides \\ []) do
+    name = :"test_env_#{unique_positive_integer()}"
+    opts = Map.merge(%{type: :string, default: nil}, Map.new(overrides))
+    os_env_name = name |> to_string() |> String.upcase()
+    %{name: name, opts: opts, os_env_name: os_env_name}
+  end
+
+  defp error(param, message), do: "#{param.os_env_name} #{message}"
+end


### PR DESCRIPTION
## Changes

This PR brings in the helper for dealing with operator configuration. The helper is an expanded version originally presented in https://github.com/VeryBigThings/engineering/issues/43 with following changes:

- Helper module is renamed to `VBT.Provider`
- Support for generating OS env template:
![image](https://user-images.githubusercontent.com/202498/74132566-22b46e00-4be7-11ea-9917-b376dcc19e08.png)
- Docs & typespecs in client module:
![image](https://user-images.githubusercontent.com/202498/74132466-eaad2b00-4be6-11ea-9f58-5bb5c0ebbe08.png)
- Compile-time purging of dev/test defaults. Constants and expression used in dev/test won't be included in prod release. Consequently, if some functions are used only in dev/test, they need to be conditionally defined ([example](https://github.com/VeryBigThings/banmed-telehealth-backend/commit/dec37177d54be381b08e4647a070c2ed77db4fdd)).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works