### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/vbt.yaml
+++ b/.github/workflows/vbt.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           MIX_ENV=test mix compile --warnings-as-errors
           MIX_ENV=dev mix compile --warnings-as-errors
-          MIX_ENV=prod mix compile --warnings-as-error
+          MIX_ENV=prod mix compile --warnings-as-errors
 
       - name: Check code format
         run: mix format --check-formatted

--- a/.github/workflows/vbt_new.yaml
+++ b/.github/workflows/vbt_new.yaml
@@ -62,7 +62,7 @@ jobs:
           cd vbt_new
           MIX_ENV=test mix compile --warnings-as-errors
           MIX_ENV=dev mix compile --warnings-as-errors
-          MIX_ENV=prod mix compile --warnings-as-error
+          MIX_ENV=prod mix compile --warnings-as-errors
 
       - name: Check code format
         run: cd vbt_new && mix format --check-formatted


### PR DESCRIPTION
There's a typo in compilation command for production environment in both GitHub workflows.