### PR TITLE
Enable trim in normalize

### DIFF
--- a/test/vbt/validation_test.exs
+++ b/test/vbt/validation_test.exs
@@ -68,6 +68,13 @@ defmodule VBT.ValidationTest do
       assert [{"can't be blank", _}] = field_errors(changeset, :bar)
     end
 
+    test "supports trim" do
+      assert Validation.normalize(
+               %{"foo" => "   value   "},
+               foo: {:string, trim: true}
+             ) == {:ok, %{foo: "value"}}
+    end
+
     test "supports custom validation" do
       assert {:error, changeset} =
                Validation.normalize(


### PR DESCRIPTION
## Changes
Added support in `VBT.Validate.normalize`  for trimming.
`VBT.Validation.normalize(%{"foo" => "   value   "}, foo: {:string, trim: true}) == {:ok, %{foo: "value"}}`
This came up as improved solution from solving issue below.
 I wanted to be able to trim in the normalize function easily. 
Doing it somewhere outside of process of normalization felt misplaced or rather needlessly repetitive.

## Ticket
[BRV-1206](https://verybigthings.atlassian.net/browse/BRV-1206)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have tried to find clearer solution before commenting hard-to-understand parts of code
- [x] I have added tests that prove my fix is effective or that my feature works

